### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,15 @@ Vendor stylesheets and JavaScripts should go in each of their `/bower_components
 ### Deploying to GitHub Pages
 
     middleman build
-    middleman publish
+    middleman deploy
+    
+Note :
+- If you get an error with `middleman build`, make sure [Imagemagik](http://www.imagemagick.org/script/index.php) is installed `brew install imagemagick`
+- If you deploy on Github pages, don't forget to uncomment these two lines in `config.rb` :
+```
+  activate :relative_assets
+  set :relative_links, true
+```
 
 ## Contributing
 


### PR DESCRIPTION
`middleman publish` doesn't exist, with `middleman deploy`it's better ! Add a note about `middleman build` which here requires ImageMagik
